### PR TITLE
RRAPIS-1704 (Minor): Refactoring auth interface to use Config object

### DIFF
--- a/src/provenaclient/auth/helpers.py
+++ b/src/provenaclient/auth/helpers.py
@@ -144,7 +144,7 @@ def keycloak_refresh_token_request(token_endpoint: str, client_id: str, scopes: 
     response = requests.post(token_endpoint, data=data)
 
     if (not response.status_code == 200):
-            err_msg = "The token used for refresh is invalid or has potentially expired. Something went wrong during token refresh. Status code: {response.status_code}."
+            err_msg = f"The token used for refresh is invalid or has potentially expired. Something went wrong during token refresh. Status code: {response.status_code}."
             logger.error(err_msg)
             raise Exception(err_msg)
 

--- a/src/provenaclient/auth/implementations.py
+++ b/src/provenaclient/auth/implementations.py
@@ -4,11 +4,10 @@ import requests
 import webbrowser
 import time
 import os
-from jose import JWTError  # type: ignore
 from provenaclient.auth.helpers import AccessToken, Tokens, keycloak_refresh_token_request, validate_access_token, retrieve_keycloak_public_key
 import json
-import logging
 from provenaclient.auth.manager import DEFAULT_LOG_LEVEL
+from provenaclient.utils.config import Config
 
 
 class DeviceFlow(AuthManager):
@@ -18,7 +17,7 @@ class DeviceFlow(AuthManager):
     device_endpoint: str
     token_endpoint: str
 
-    def __init__(self, keycloak_endpoint: str, client_id: str, log_level: Optional[LogType] = None) -> None:
+    def __init__(self, config: Config, client_id: str, log_level: Optional[LogType] = None) -> None:
         f""" Create and generate a DeviceFlow object. The tokens are automatically refreshed when
         accessed through the get_auth() function.
 
@@ -38,12 +37,12 @@ class DeviceFlow(AuthManager):
         # construct parent class and include log level
         super().__init__(log_level=log_level)
 
-        self.keycloak_endpoint = keycloak_endpoint
+        self.keycloak_endpoint = config.keycloak_endpoint
         self.client_id = client_id
         self.scopes: list = []
         self.file_name = ".tokens.json"
-        self.device_endpoint = f'{keycloak_endpoint}/protocol/openid-connect/auth/device'
-        self.token_endpoint = f'{keycloak_endpoint}/protocol/openid-connect/token'
+        self.device_endpoint = f'{self.keycloak_endpoint}/protocol/openid-connect/auth/device'
+        self.token_endpoint = f'{self.keycloak_endpoint}/protocol/openid-connect/token'
 
         try:
             # First thing to do here is obtain the keycloak public key.
@@ -430,7 +429,7 @@ class OfflineFlow(AuthManager):
 
     public_key: str
 
-    def __init__(self, keycloak_endpoint: str, client_id: str, offline_token: Optional[str] = None, offline_token_file: Optional[str] = None, log_level: Optional[LogType] = None) -> None:
+    def __init__(self, config: Config, client_id: str, offline_token: Optional[str] = None, offline_token_file: Optional[str] = None, log_level: Optional[LogType] = None) -> None:
         f"""Create and generate an OfflineFlow object. Instatiate from provided offline token, or attempt to read
         one from file and generate the access token. Can provide the offline token directly, a file for it stored as plain text.
 
@@ -457,11 +456,11 @@ class OfflineFlow(AuthManager):
         # construct parent class and include log level
         super().__init__(log_level=log_level)
 
-        self.keycloak_endpoint = keycloak_endpoint
+        self.keycloak_endpoint = config.keycloak_endpoint
         self.client_id = client_id
         self.scopes: list = []
 
-        self.token_endpoint = f'{keycloak_endpoint}/protocol/openid-connect/token'
+        self.token_endpoint = f'{self.keycloak_endpoint}/protocol/openid-connect/token'
 
         try:
             # First thing to do here is obtain the keycloak public key.

--- a/tests/adhoc.py
+++ b/tests/adhoc.py
@@ -15,7 +15,7 @@ async def main() -> None:
         realm_name="rrap"
     )
 
-    auth = DeviceFlow(keycloak_endpoint=config.keycloak_endpoint,
+    auth = DeviceFlow(config=config,
                       client_id="client-tools", log_level=Log.DEBUG)
 
     client = ProvenaClient(config=config, auth=auth)


### PR DESCRIPTION
# Jira-1704 (Minor): Refactoring auth interface to use Config object

## JIRA [RRAPIS-1704](https://jira.csiro.au/browse/RRAPIS-1704)

## Description

uses the config interface as part of constructor to auth objects so that the domain and realm name can be defined once in client code. 

Before:
```
PROVENA_DOMAIN = "mds.gbrrestoration.org"
REALM_NAME = "rrap"
KC_ENDPOINT = f"auth.{PROVENA_DOMAIN}/auth/realms/{REALM_NAME}"
PROVENA_CLIENT_ID = "automated-access"

auth = DeviceFlow(
        keycloak_endpoint=KC_ENDPOINT,
        client_id=PROVENA_CLIENT_ID
    )
    client = ProvenaClient(
        auth=auth,
        config=Config(
            domain=PROVENA_DOMAIN,
            realm_name=REALM_NAME
        )
    )
```
After:
```
PROVENA_DOMAIN = "mds.gbrrestoration.org"
REALM_NAME = "rrap"
PROVENA_CLIENT_ID = "automated-access"

config = Config(
            domain=PROVENA_DOMAIN,
            realm_name=REALM_NAME
        )
auth = DeviceFlow(
        config=config,
        client_id=PROVENA_CLIENT_ID
    )
    client = ProvenaClient(
        auth=auth,
        config=config
    )
```
This is simpler for the user as the default keycloak endpoint format is baked into the Config class, and each variable is just defined/used once.