### PR TITLE
fix: (auth-api client) user link look up - Issue #26

### DIFF
--- a/src/provenaclient/clients/auth_client.py
+++ b/src/provenaclient/clients/auth_client.py
@@ -750,7 +750,7 @@ class AuthClient(ClientService):
         Returns:
             UserLinkUserLookupResponse: The response indicating link
         """
-        return await parsed_get_request_with_status(
+        return await parsed_get_request(
             client=self,
             url=self._build_endpoint(AuthEndpoints.GET_LINK_USER_LOOKUP),
             error_message="Failed to lookup user in link service.",


### PR DESCRIPTION
Fix for #26 

## Description

Corrected the parse response functino call to not use the one with_status because the user link lookup endpoint does not provide a status response.