### PR TITLE
fix: Increasing httpx timeout to 30s global to mirror api gateway

### DIFF
--- a/src/provenaclient/utils/http_client.py
+++ b/src/provenaclient/utils/http_client.py
@@ -1,4 +1,4 @@
-'''
+"""
 Created Date: Monday June 17th 2024 +1000
 Author: Peter Baker
 -----
@@ -10,28 +10,32 @@ Description: A HTTP client which wraps HTTPx async so that we can swap out a dif
 HISTORY:
 Date      	By	Comments
 ----------	---	---------------------------------------------------------
-'''
+"""
 
 from typing import Any, List, Optional, Union
 import httpx
 from provenaclient.auth.helpers import HttpxBearerAuth
 from provenaclient.utils.helpers import JsonData
 
-# 60s timeout for connecting, and a 10s timeout elsewhere.
-timeout = httpx.Timeout(timeout=10.0, connect=60.0)
+# 30s total timeout (mirroring API Gateway timeout anyway)
+timeout = httpx.Timeout(timeout=30.0)
 
 # L1 interface.
 
 
 class HttpClient:
-
-    """This class only contains static methods as it acts as an HTTP client and provides a layer over these static methods 
+    """This class only contains static methods as it acts as an HTTP client and provides a layer over these static methods
     and makes them easily identifiable within the codebase.
     """
 
     @staticmethod
-    async def make_get_request(url: str, params: Optional[dict[str, Any]] = None, auth: Optional[HttpxBearerAuth] = None, headers: Optional[dict[str, Any]] = None) -> httpx.Response:
-        """ Makes an asynchronous HTTP GET request to the specified URL using the provided parameters, authentication, and headers.
+    async def make_get_request(
+        url: str,
+        params: Optional[dict[str, Any]] = None,
+        auth: Optional[HttpxBearerAuth] = None,
+        headers: Optional[dict[str, Any]] = None,
+    ) -> httpx.Response:
+        """Makes an asynchronous HTTP GET request to the specified URL using the provided parameters, authentication, and headers.
 
         Parameters
         ----------
@@ -54,8 +58,13 @@ class HttpClient:
             return response
 
     @staticmethod
-    async def make_delete_request(url: str,  auth: HttpxBearerAuth, params: Optional[dict[str, Any]] = None, headers: Optional[dict[str, Any]] = None) -> httpx.Response:
-        """ Makes an asynchronous HTTP DELETE request to the specified URL using the provided parameters, authentication, and headers.
+    async def make_delete_request(
+        url: str,
+        auth: HttpxBearerAuth,
+        params: Optional[dict[str, Any]] = None,
+        headers: Optional[dict[str, Any]] = None,
+    ) -> httpx.Response:
+        """Makes an asynchronous HTTP DELETE request to the specified URL using the provided parameters, authentication, and headers.
 
         Parameters
         ----------
@@ -74,12 +83,21 @@ class HttpClient:
             The response from the server as an httpx.Response object.
         """
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.delete(url, params=params, headers=headers, auth=auth)
+            response = await client.delete(
+                url, params=params, headers=headers, auth=auth
+            )
             return response
 
     @staticmethod
-    async def make_post_request(url: str, auth: HttpxBearerAuth, params: Optional[dict[str, Any]] = None, data: Union[Optional[dict[str, Any]], Optional[List[dict[str,Any]]]] = None, files: Optional[dict[str, tuple[str, bytes, str]]] = None, headers: Optional[dict[str, Any]] = None) -> httpx.Response:
-        """ Makes an asynchronous HTTP POST request to the specified URL with the provided data, authentication, and headers.
+    async def make_post_request(
+        url: str,
+        auth: HttpxBearerAuth,
+        params: Optional[dict[str, Any]] = None,
+        data: Union[Optional[dict[str, Any]], Optional[List[dict[str, Any]]]] = None,
+        files: Optional[dict[str, tuple[str, bytes, str]]] = None,
+        headers: Optional[dict[str, Any]] = None,
+    ) -> httpx.Response:
+        """Makes an asynchronous HTTP POST request to the specified URL with the provided data, authentication, and headers.
 
         Parameters
         ----------
@@ -102,12 +120,20 @@ class HttpClient:
             The response from the server as an httpx.Response object.
         """
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(url, params=params, json=data, headers=headers, files=files, auth=auth)
+            response = await client.post(
+                url, params=params, json=data, headers=headers, files=files, auth=auth
+            )
             return response
 
     @staticmethod
-    async def make_put_request(url: str, auth: HttpxBearerAuth, params: Optional[dict[str, Any]] = None, data: Optional[JsonData] = None, headers: Optional[dict[str, Any]] = None) -> httpx.Response:
-        """ Makes an asynchronous HTTP put request to the specified URL with the provided data, authentication, and headers.
+    async def make_put_request(
+        url: str,
+        auth: HttpxBearerAuth,
+        params: Optional[dict[str, Any]] = None,
+        data: Optional[JsonData] = None,
+        headers: Optional[dict[str, Any]] = None,
+    ) -> httpx.Response:
+        """Makes an asynchronous HTTP put request to the specified URL with the provided data, authentication, and headers.
 
         Parameters
         ----------
@@ -128,5 +154,7 @@ class HttpClient:
             The response from the server as an httpx.Response object.
         """
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.put(url, params=params, json=data, headers=headers, auth=auth)
+            response = await client.put(
+                url, params=params, json=data, headers=headers, auth=auth
+            )
             return response


### PR DESCRIPTION
## Description

Increases timeout from 10s to 30s - finding that in real client context the cold starts are causing problems (maybe we hit warmup endpoint when the client starts?). This is just a bandaid fix.
