### PR TITLE
docs: Added a "how to contribute" section in contributing doc and updated a few other things.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing Guidelines
 
-This is the contributing guidelines for the client library.
+This document outlines the contributing guidelines for the Provena client library. Contributions are welcome for new features, bug fixes, and documentation updates.
+
+---
 
 ## Usage
 
@@ -28,11 +30,91 @@ You can then make vs code use this environment easily with `ctrl + shift + p` se
 5) Verify that your poetry is now running, using the command `poetry --version`.
 
 
+## How to contribute to the Provena Python Client
+
+### 1) Initial Setup
+
+1. **Ensure You Have an IDE Installed**: Start by setting up your preferred Integrated Development Environment (IDE) like VSCode, PyCharm, etc.
+2. **Clone the Repository**: Use the following command to clone the Provena client repository locally: `git clone https://github.com/provena/provena-python-client.git `
+3. **Install Requirements**: The Provena Python client uses Poetry for dependency management. Install Poetry if it's not already installed, following the steps above. 
+4. **Set Up Mypy for Static Type Checking**: Ensure you have Mypy configured to check for type errors. You can run Mypy manually: `poetry run mypy` or `python run mypy` if using local .venv
+
+### 2) Codebase Layout and Contributing
+
+Before making any contributions, it's important to understand the core structure of the Provena Python Client.
+
+- **Core Directory Layout**:
+
+    - **docs**: All documentation is located here and should be updated if your contribution involves documentation changes or additions.
+    - **src/provenaclient**: This directory contains the core functionality of the Provena client. Any new features, bug fixes, or changes to the core logic should be made here.
+    - **tests**: All unit and integration tests are located in this directory. If your contribution involves code changes or new features, corresponding tests should be written or updated here.
+    
+- **Where to Add New Features**:
+
+    - Any new feature should be added within the `src/provenaclient/` directory, following the existing architecture structure and file organisation.
+    - If you are extending or updating an existing feature or API endpoint, locate the relevant module and update the code accordingly to ensure consistency with the existing architecture.
+
+- **Adding Tests**:
+
+    - All new features or bug fixes may include corresponding tests in the `tests` directory if appropriate.
+    - Use Pytest for writing unit or integration tests to ensure that the new functionality is properly covered.
+    - If you're adding new test cases, ensure they are comprehensive and maintain test coverage for the affected code.
+
+- **Code Style**:
+
+    - Maintain consistency with the existing codebase in terms of structure, style, and naming conventions.
+    - Use docstrings to document functions, classes, and modules where necessary, ensuring the code is well-documented for future contributors.
+    - Ensure that all functions and methods are properly typed for static type checking, and use Mypy to validate the typing.
+
+
+### 3) Create a New Branch
+
+Name your branch descriptively, e.g., `<change scope:feat|fix|docs>-<jira-ticket-name>`.
+
+### 4) Commit Message Conventions
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for commit messages. This helps automate the versioning and release process.
+
+- Conventional Commits Examples:
+
+    - **feat:** A new feature.
+    - **fix:** A bug fix.
+    - **chore:** Changes to the build process or auxiliary tools and libraries.
+    - **docs:** Documentation only changes.
+    - **style:** Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
+    - **refactor:** A code change that neither fixes a bug nor adds a feature.
+    - **perf:** A code change that improves performance.
+    - **test:** Adding missing tests or correcting existing tests.
+
+**Note:** Commits with types of `docs`, `chore`, `style`, `refactor`, and `test` will not trigger a version change.
+
+### 5) Develop and Commit
+
+- Make your desired changes in your branch.
+- Commit your changes to your upstream branch and use meaningful commit messages.
+
+### 6) Open a Pull Request (PR)
+
+- When your feature is complete, open a PR to the main branch.
+- Ensure that your PR title adheres and begins by one of the Conventional Commits specification keywords outlined above.
+- Ensure your PR description is clear and outlines the changes made.
+- Ensure that the CI (Continuous Integration) has successfully passed for your latest commit.
+
+### 7) Review and Squash Merge
+
+- Request reviews from at least one team member within the Provena organisation or part of the client library development.
+- Once approved, squash merge the PR into main with a specific commit message that summarises the changes, e.g., `feat: added new endpoint in job-api` or re-use the PR title.
+
+### 8) CI/CD Flow
+
+After merging, the CI/CD pipeline will run automatically, deploying the changes and updating the version as needed.
+
+
 ## Provena Client CI/CD and Release Process
 
 ## Overview
 
-The Provena client uses GitHub Actions for CI/CD, producing automated deployments to our PyPI account.
+The Provena client uses GitHub Actions for CI/CD, producing automated deployments to our [PyPI account](https://pypi.org/project/provenaclient/).
 
 ## Continuous Integration (CI)
 
@@ -75,23 +157,6 @@ The Provena Client uses `python-semantic-release` for automated versioning and r
 - **Upload to PyPI and GitHub Releases:** Set to true.
 - **Automatic Version Commit:** `commit_version_number = true` ensures that the version number is automatically committed back to the repository after a release, keeping the `pyproject.toml` and `src/provenaclient/__init__.py` files up to date.
 
-### Commit Message Conventions
-
-Follow the Conventional Commits specification. Examples:
-
-- **feat:** A new feature.
-- **fix:** A bug fix.
-- **chore:** Changes to the build process or auxiliary tools and libraries.
-- **docs:** Documentation only changes.
-- **style:** Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
-- **refactor:** A code change that neither fixes a bug nor adds a feature.
-- **perf:** A code change that improves performance.
-- **test:** Adding missing tests or correcting existing tests.
-
-**Note:** Commits with types of `docs`, `chore`, `style`, `refactor`, and `test` will not trigger a version change.
-
-More information can be found here: [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/).
-
 ## Release Process
 
 On merging to the main branch, `python-semantic-release` automates the following steps:
@@ -120,33 +185,6 @@ The distribution files are uploaded to GitHub Releases.
 
 The new version number is committed back to the repository, ensuring the `pyproject.toml` and `src/provenaclient/__init__.py` files are up-to-date.
 
-## Best Practices for Adding New Features or Making Changes
-
-### Create a New Branch
-
-Name your branch descriptively, e.g., `<change scope:feat|fix|docs>-<jira-ticket-name>`.
-
-### Develop and Commit
-
-- Make changes in your branch.
-- Use meaningful commit messages following the Conventional Commits specification.
-
-### Open a Pull Request (PR)
-
-- When your feature is complete, open a PR to the main branch.
-- Ensure that your PR title adheres to the Conventional Commits specification.
-- Ensure your PR description is clear and outlines the changes made.
-- Ensure that the CI (Continuous Integration) has successfully passed for your latest commit.
-
-### Review and Squash Merge
-
-- Request reviews from at least one team member within the Provena organization and part of the client library development.
-- Once approved, squash merge the PR into main with a specific commit message that summarizes the changes, e.g., `feat: added new endpoint in job-api` or re-use the PR title.
-
-### CI/CD Flow
-
-After merging, the CI/CD pipeline will run automatically, deploying the changes and updating the version as needed.
-
 ## Overall Summary
 
 This setup ensures a streamlined and automated release process for the Provena Client, with CI/CD pipelines handling testing and deployment, and `python-semantic-release` managing semantic versioning and PyPI releases.
@@ -158,4 +196,3 @@ This setup ensures a streamlined and automated release process for the Provena C
 ## Credits
 
 `provenaclient` was created with [`cookiecutter`](https://cookiecutter.readthedocs.io/en/latest/) and the `py-pkgs-cookiecutter` [template](https://github.com/py-pkgs/py-pkgs-cookiecutter).
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ Before making any contributions, it's important to understand the core structure
 
     - Any new feature should be added within the `src/provenaclient/` directory, following the existing architecture structure and file organisation.
     - If you are extending or updating an existing feature or API endpoint, locate the relevant module and update the code accordingly to ensure consistency with the existing architecture.
+    - See the README in `src/` for more information on how to contribute to adding new features to Provena Python Client! 
 
 - **Adding Tests**:
 


### PR DESCRIPTION
# Jira-1771: Minor

## JIRA [Ticket 1771](https://jira.csiro.au/browse/RRAPIS-1771)

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?

## Description

- Updated the contributing docs, to include a section on how to specifically contribute to the Provena Python Clients
- Enhanced the introduction and cleaned/updated a few other minor things. 


## Notes for reviewer
- I have created a separate branch/doc that will focus on creating a doc that covers the different directories and the general L1/L2/L3 layers within `src` as we discussed. I will branch off from this branch, and then in the contributing.md I will point a link to the doc within `src` if the reader wants more information. 
